### PR TITLE
Debug symbols support

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -48,7 +48,7 @@
       }],
       ["OS=='mac'", {
         "variables": {
-           "ffmpeg_version": "1.21.rc5"
+           "ffmpeg_version": "1.21.rc6"
         },
         "defines": [
           "__STDC_CONSTANT_MACROS"

--- a/install_ffmpeg.js
+++ b/install_ffmpeg.js
@@ -182,7 +182,7 @@ async function darwin() {
     else throw e;
   });
 
-  const version = '1.21.rc5';
+  const version = '1.21.rc6';
   const ffmpegFilename = `ffmpeg-ffprobe-shared-darwin-x86_64.${version}`;
 
   await access(`ffmpeg/${ffmpegFilename}`, fs.constants.R_OK).catch(async () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beamcoder-prebuild",
-  "version": "0.6.10-rc.25",
+  "version": "0.6.10-rc.26",
   "description": "Node.js native bindings to FFmpeg.",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
- [x] Update ffmpeg libs to those with debug symbols uploaded to Sentry

We will still need to decide how best to upload symbols from beamcoder itself. See my comment here: https://app.asana.com/0/828043401736247/1199615025912181